### PR TITLE
BUG Fixing broken use of Filesystem::$folder_create_mask

### DIFF
--- a/code/VersionedFileExtension.php
+++ b/code/VersionedFileExtension.php
@@ -146,7 +146,7 @@ class VersionedFileExtension extends DataExtension {
 
 			if (is_dir($oldVersions)) {
 				if (!is_dir($newVersions)) {
-					mkdir($newVersions, Filesystem::$folder_create_mask, true);
+					mkdir($newVersions, Config::inst()->get('Filesystem', 'folder_create_mask'), true);
 				}
 
 				rename($oldVersions, $newVersions);


### PR DESCRIPTION
Fixing another case where 3.1 fails, trying to access a private static.

The fix is to use the Config layer to fetch this variable instead.
