### PR TITLE
Fix deprecation warning for DB query and fix task counting

### DIFF
--- a/code/FileVersionCreationTask.php
+++ b/code/FileVersionCreationTask.php
@@ -26,20 +26,21 @@ class FileVersionCreationTask extends BuildTask {
 	 * @param HTTPRequest $request
 	 */
 	public function run($request) {
-		$versionless = DataObject::get(
-			'File',
-			'"File"."ClassName" <> \'Folder\' AND "FileVersion"."FileID" IS NULL')
-				->leftJoin("FileVersion",'"FileVersion"."FileID" = "File"."ID"');
+		$versionless = File::get()->leftJoin(
+			'FileVersion',
+			'"FileVersion"."FileID" = "File"."ID"'
+		)->where('"File"."ClassName" <> \'Folder\' AND "FileVersion"."FileID" IS NULL');
+		$createdVersions = 0;
 
 		if($versionless) foreach($versionless as $file) {
-			$file->createVersion();
+			if($file->createVersion()) ++$createdVersions;
 		}
 
-		if($versionless) {
+		if($createdVersions) {
 			echo _t(
 				'FileVersionCreationTask.Created',
 				"Created {count} file version records.",
-				array('count' => $versionless->Count())
+				array('count' => $createdVersions)
 			);
 		} else {
 			echo _t(

--- a/code/VersionedFileExtension.php
+++ b/code/VersionedFileExtension.php
@@ -250,17 +250,17 @@ class VersionedFileExtension extends DataExtension {
 	/**
 	 * Creates a new file version and sets it as the current version.
 	 *
-	 * @param bool $write
+	 * @return boolean Whether file version is created
 	 */
 	public function createVersion() {
-		if(!file_exists($this->owner->getFullPath())) return;
+		if(!file_exists($this->owner->getFullPath())) return false;
 
 		$version = new FileVersion();
 		$version->FileID = $this->owner->ID;
 		$version->write();
 
 		$this->owner->CurrentVersionID = $version->ID;
-		$this->owner->write();
+		return (bool) $this->owner->write();
 	}
 
 }


### PR DESCRIPTION
Fixed query causing deprecation warning and also fixed the counting as it was counting files that didn't exist and therefore not versioned.
