### PR TITLE
DOC Improve SS4 upgrade guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ SilverStripe Versioned Files Module
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/symbiote/silverstripe-versionedfiles/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/symbiote/silverstripe-versionedfiles/?branch=master)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 
-**IMPORTANT**: File versioning is [built-in](https://docs.silverstripe.org/en/4/developer_guides/files/file_management/#file-versioning) with SilverStripe 4.x. There is currently no migration path from this module. Current file versions are handled by SilverStripe’s built-in upgrade tooling. Both past file metadata versions (in `FileVersion` table) and content versions (in `assets/_versions`) are retained, but they’re no longer accessible via the CMS UI. If required, those versions can be retrieved by a developer.
+# Upgrading to Silverstripe CMS 4
+
+This is a legacy module for Silverstripe CMS 3.
+
+File versioning is [built-in](https://docs.silverstripe.org/en/4/developer_guides/files/file_management/#file-versioning) with Silverstripe CMS 4. There is currently no migration path from this module. Current file versions are handled by Silverstripe CMS’s built-in upgrade tooling. Both past file metadata versions (in `FileVersion` table) and content versions (in `assets/_versions`) are retained, but they’re no longer accessible via the CMS UI. If required, those versions can be retrieved by a developer.
+
+Read the [Keeping archived assets](https://docs.silverstripe.org/en/4/developer_guides/files/file_migration/#keeping-archived-assets) documentation article to configure your Silverstripe CMS 4 project to preserved archived files.
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SilverStripe Versioned Files Module
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/symbiote/silverstripe-versionedfiles/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/symbiote/silverstripe-versionedfiles/?branch=master)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 
-# Upgrading to Silverstripe CMS 4
+## Upgrading to Silverstripe CMS 4
 
 This is a legacy module for Silverstripe CMS 3.
 


### PR DESCRIPTION
I wanted to know if we provided an SS4 upgrade path and I managed to miss this bit of info even if it was the very first thing on the page.

I've made it an header instead and added extra bits of guidance around archived assets.